### PR TITLE
Disable nrf supplied lwm2m_carrier (ST-1043)

### DIFF
--- a/lib/bin/lwm2m_carrier/CMakeLists.txt
+++ b/lib/bin/lwm2m_carrier/CMakeLists.txt
@@ -36,6 +36,7 @@ ncs_add_partition_manager_config(pm.yml.lwm2m_carrier)
 zephyr_include_directories(include)
 zephyr_library()
 zephyr_library_sources(
-  os/lwm2m_carrier.c
+  # disable nrf supplied lwm2m_carrier in favor of our own
+  # os/lwm2m_carrier.c
   os/lwm2m_os.c
 )


### PR DESCRIPTION
NRF SDK update to disable lwm2m_carrier in favor of our own implementation.

Proposed flow here is that will keep a long lived `silvertree-changes` branch that will rebase onto the upstream during the upgrade. We can issue PRs against that branch with changes like this one. `west.yml` will always point to a SHA from `silvertree-changes` branch.

Once this PR is approved and merged, we can update lte `west.yml` to point to our fork at the new SHA.