### PR TITLE
Upgrade memfault-firmware-sdk to version 1.2.4

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -223,7 +223,7 @@ manifest:
       remote: throwtheswitch
     - name: memfault-firmware-sdk
       path: modules/lib/memfault-firmware-sdk
-      revision: 0.43.3
+      revision: 1.2.4
       remote: memfault
     - name: ant
       repo-path: sdk-ant


### PR DESCRIPTION
- Among other things, this contains a fix for incorrect stack usage calculation